### PR TITLE
Relax abuse-handling

### DIFF
--- a/src/main/scala/ch/seidel/kutu/akka/CompetitionCoordinatorClientActor.scala
+++ b/src/main/scala/ch/seidel/kutu/akka/CompetitionCoordinatorClientActor.scala
@@ -90,13 +90,13 @@ class CompetitionCoordinatorClientActor(wettkampfUUID: String) extends Persisten
   }
 
   override def preStart(): Unit = {
-    log.info(s"Starting CompetitionCoordinatorClientActor for $persistenceId, $wettkampf")
+    log.info(s"Starting for $persistenceId, $wettkampf")
     rebuildWettkampfMap()
   }
 
   override def postStop(): Unit = {
     liveticker.cancel()
-    log.info(s"CompetitionCoordinatorClientActor stopped: $persistenceId, $wettkampf")
+    log.info(s"stopped: $persistenceId, $wettkampf")
     wsSend.values.flatten.foreach(context.stop)
   }
 

--- a/src/main/scala/ch/seidel/kutu/http/ReportRoutes.scala
+++ b/src/main/scala/ch/seidel/kutu/http/ReportRoutes.scala
@@ -25,6 +25,18 @@ trait ReportRoutes extends SprayJsonSupport with JsonSupport with AuthSupport wi
   lazy val reportRoutes: Route = {
     (handleCID & extractUri) { (clientId: String, uri: Uri) =>
       pathPrefixLabeled("report", "report") {
+        pathLabeled("abused", "abused") {
+          val abusedClients = AbuseHandler.getAbusedClients()
+          complete(HttpEntity(ContentTypes.`text/html(UTF-8)`,
+            abusedClients
+              .map(abused => abused.split("//"))
+              .map(abusedArr => s"${abusedArr(0).split("@")(0)}</td><td>${abusedArr(0).split("@")(1).split(":")(0)}</td><td>${abusedArr(1)}")
+              .mkString(
+                s"<html><body><h1>${abusedClients.size} Abused clients</h1><table><tr><td>",
+                "</td></tr><tr><td>",
+                "</td></tr></table></body></html>")))
+
+        }~
         pathPrefix(JavaUUID) { competitionId =>
           import AbuseHandler._
           if (!wettkampfExists(competitionId.toString)) {

--- a/src/main/scala/ch/seidel/kutu/http/WettkampfRoutes.scala
+++ b/src/main/scala/ch/seidel/kutu/http/WettkampfRoutes.scala
@@ -246,6 +246,7 @@ trait WettkampfRoutes extends SprayJsonSupport
             authenticated() { userId =>
               entity(as[StartDurchgang]) { sd =>
                 if (userId.equals(wkuuid.toString)) {
+                  AbuseHandler.clearAbusedClients()
                   complete(CompetitionCoordinatorClientActor.publish(sd, clientId))
                 } else {
                   complete(StatusCodes.Conflict)
@@ -331,7 +332,7 @@ trait WettkampfRoutes extends SprayJsonSupport
                               AthletIndexActor.publish(ResyncIndex)
                               CompetitionCoordinatorClientActor.publish(RefreshWettkampfMap(wkuuid.toString), clientId)
                               CompetitionRegistrationClientActor.publish(RegistrationChanged(wkuuid.toString), clientId)
-
+                              AbuseHandler.clearAbusedClients()
                               wettkampf
                             } finally {
                               is.close()


### PR DESCRIPTION
- reset on every round-start
- provide report at api/report/abused
- provide prometheus-metric for abused clients count