### PR TITLE
Fix/compute staging

### DIFF
--- a/src/main/scala/ch/seidel/kutu/squad/RiegenSplitter.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/RiegenSplitter.scala
@@ -7,7 +7,18 @@ import scala.annotation.tailrec
 
 trait RiegenSplitter {
   private val logger = LoggerFactory.getLogger(classOf[RiegenSplitter])
-  
+
+  private def computeSplitPos(size: Int, targetSize: Option[Int]): Int = {
+    val fallback = size / 2
+    targetSize match {
+      case Some(target) if target > 0 && size > 1 =>
+        val bounded = math.max(1, math.min(size - 1, target))
+        // Prefer non-symmetric splits when a meaningful target exists.
+        if bounded == fallback && size > 2 then math.max(1, fallback - 1) else bounded
+      case _ => fallback
+    }
+  }
+
   def groupKey(grplst: List[WertungView => String])(wertung: WertungView): String = {
     grplst.foldLeft(""){(acc, f) =>
       acc + "," + f(wertung)
@@ -19,7 +30,8 @@ trait RiegenSplitter {
     val ret = sugg.sortBy(_._2.size).reverse
     //logger.debug((ret.size, riegencnt))
     if ret.size < requiredRiegenCount then {
-      splitToRiegenCount(split(ret.head, ".", cache) ++ ret.tail, requiredRiegenCount, cache)
+      val targetSize = math.ceil(1d * ret.map(_._2.size).sum / math.max(1, requiredRiegenCount)).toInt
+      splitToRiegenCount(split(ret.head, ".", cache, Some(targetSize)) ++ ret.tail, requiredRiegenCount, cache)
     }
     else {
       //logger.debug(ret.mkString("\n"))
@@ -32,14 +44,14 @@ trait RiegenSplitter {
     //cache.clear
     val ret = sugg.sortBy(_._2.size).reverse
     if ret.nonEmpty && ret.head._2.size > maxRiegenTurnerCount then {
-      splitToMaxTurnerCount(split(ret.head, "#", cache) ++ ret.tail, maxRiegenTurnerCount, cache)
+      splitToMaxTurnerCount(split(ret.head, "#", cache, Some(maxRiegenTurnerCount)) ++ ret.tail, maxRiegenTurnerCount, cache)
     }
     else {
       ret
     }
   }
   
-  private def split[A](riege: (String, Seq[A]), delimiter: String, cache: scala.collection.mutable.Map[String, Int]): Seq[(String, Seq[A])] = {
+  private def split[A](riege: (String, Seq[A]), delimiter: String, cache: scala.collection.mutable.Map[String, Int], targetSize: Option[Int] = None): Seq[(String, Seq[A])] = {
     val (key, r) = riege
     val oldKey1 = (key + delimiter).split(delimiter).headOption.getOrElse("Riege")
     val oldList = r.toList
@@ -50,7 +62,7 @@ trait RiegenSplitter {
     }
     val key1 = if key.contains(delimiter) then key else oldKey1 + delimiter + occurences(oldKey1)
     val key2 = oldKey1 + delimiter + occurences(oldKey1)
-    val splitpos = r.size / 2
+    val splitpos = computeSplitPos(r.size, targetSize)
     List((key1, oldList.take(splitpos)), (key2, oldList.drop(splitpos)))
   }
   

--- a/src/main/scala/ch/seidel/kutu/squad/Stager.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/Stager.scala
@@ -16,7 +16,7 @@ trait Stager extends Mapper {
   def buildPairs(geraeteOriginal: Int, maxGeraeteRiegenSize: Int, geraeteriegen: GeraeteRiegen,
       targetDiff: Int = Int.MaxValue, fairnessWeight: Int = 50, splitWeight: Int = 30, cohesionWeight: Int = 20): GeraeteRiegen = {
     val sum = geraeteriegen.sizeOfAll
-    val (eqsize, rounds) = computeDimensions(sum, geraeteOriginal, maxGeraeteRiegenSize, 1)
+    val (eqsize, rounds) = computeDimensions(sum, geraeteOriginal, maxGeraeteRiegenSize)
     val geraete = rounds * geraeteOriginal
     logger.debug(s"sum: $sum, eqsize: $eqsize, geraete: $geraete, gerateOriginal: $geraeteOriginal")
 
@@ -164,10 +164,16 @@ trait Stager extends Mapper {
     }
   }
   
+  /** Returns (eqsize, rounds) for evenly distributing sumOfAll athletes across geraete
+   *  slots without exceeding maxGeraeteRiegenSize per slot.
+   */
+  protected final def computeDimensions(sumOfAll: Int, geraete: Int, maxGeraeteRiegenSize: Int): (Int, Int) =
+    computeDimensionsRec(sumOfAll, geraete, maxGeraeteRiegenSize, 1)
+
   @tailrec
-  private def computeDimensions(sumOfAll: Int, geraete: Int, maxGeraeteRiegenSize: Int, level: Int): (Int, Int) = {
+  private def computeDimensionsRec(sumOfAll: Int, geraete: Int, maxGeraeteRiegenSize: Int, level: Int): (Int, Int) = {
     val eqsize = (1d * sumOfAll / (geraete * level) + 0.9d).intValue()
-    if eqsize <= maxGeraeteRiegenSize || geraete == 0 || level > 100 then (eqsize, level) else computeDimensions(sumOfAll, geraete, maxGeraeteRiegenSize, level +1)
+    if eqsize <= maxGeraeteRiegenSize || geraete == 0 || level > 100 then (eqsize, level) else computeDimensionsRec(sumOfAll, geraete, maxGeraeteRiegenSize, level + 1)
   }
   
 }

--- a/src/main/scala/ch/seidel/kutu/squad/Stager.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/Stager.scala
@@ -13,7 +13,8 @@ trait Stager extends Mapper {
 //    rebuildWertungen(suggest, riegenindex)
 //  }
 
-  def buildPairs(geraeteOriginal: Int, maxGeraeteRiegenSize: Int, geraeteriegen: GeraeteRiegen): GeraeteRiegen = {
+  def buildPairs(geraeteOriginal: Int, maxGeraeteRiegenSize: Int, geraeteriegen: GeraeteRiegen,
+      targetDiff: Int = Int.MaxValue, fairnessWeight: Int = 50, splitWeight: Int = 30, cohesionWeight: Int = 20): GeraeteRiegen = {
     val sum = geraeteriegen.sizeOfAll
     val (eqsize, rounds) = computeDimensions(sum, geraeteOriginal, maxGeraeteRiegenSize, 1)
     val geraete = rounds * geraeteOriginal
@@ -35,7 +36,7 @@ trait Stager extends Mapper {
       else {
         val withNewCandidates = nextCandidates :++ (for
           neweinteilung <- mergeCandidates(geraete, eqsize, nextCandidates.head, Set.empty)
-          s = score(geraete, eqsize, neweinteilung)
+          s = score(geraete, eqsize, neweinteilung, targetDiff, fairnessWeight, splitWeight, cohesionWeight)
           if neweinteilung.size >= geraete && !acc.contains((s, neweinteilung))
         yield {
           neweinteilung
@@ -44,12 +45,12 @@ trait Stager extends Mapper {
         withNewCandidates match {
           case candidate #:: tail if tail.isEmpty =>
 //            logger.debug("found end of LazyList")
-            val sc = (score(geraete, eqsize, candidate), candidate)
+            val sc = (score(geraete, eqsize, candidate, targetDiff, fairnessWeight, splitWeight, cohesionWeight), candidate)
             finish(acc + sc)
-          case candidate #:: tail => score(geraete, eqsize, candidate) match {
-            case 0 => 
+          case candidate #:: tail => score(geraete, eqsize, candidate, targetDiff, fairnessWeight, splitWeight, cohesionWeight) match {
+            case 0 =>
 //              logger.debug("found top scorer")
-              (score(geraete, eqsize, candidate), candidate)
+              (score(geraete, eqsize, candidate, targetDiff, fairnessWeight, splitWeight, cohesionWeight), candidate)
             case s =>
 //              logger.debug("should seek further")
               val sc = (s, candidate)
@@ -62,8 +63,32 @@ trait Stager extends Mapper {
     //logger.debug(rank, pairs.mkString("\n ", "\n ", ""))
     pairs
   }
-  protected def score(geraete: Int, eqsize: Int, einteilung: GeraeteRiegen): Long = {
-    einteilung.map(riege => math.abs(riege.size - eqsize)).sum + math.abs(geraete - einteilung.size) * einteilung.size * 10L
+  protected def score(geraete: Int, eqsize: Int, einteilung: GeraeteRiegen,
+      targetDiff: Int = Int.MaxValue, fairnessWeight: Int = 50, splitWeight: Int = 30, cohesionWeight: Int = 20): Long = {
+    if einteilung.isEmpty then {
+      Long.MaxValue
+    }
+    else {
+      val sizes = einteilung.map(_.size).toSeq
+      val spread = sizes.max - sizes.min
+      val spreadOverTarget = if targetDiff == Int.MaxValue then 0 else math.max(0, spread - targetDiff)
+      val baseDeviation = einteilung.map(riege => math.abs(riege.size - eqsize)).sum
+      val geraetePenalty = math.abs(geraete - einteilung.size) * einteilung.size * 10L
+      val splitPenalty = einteilung.flatMap(_.turnerriegen).count(_.name.contains("#"))
+      val vereinFragmentation = einteilung.toSeq.zipWithIndex
+        .flatMap { case (gr, idx) => gr.turnerriegen.flatMap(_.verein).map(v => v.id -> idx) }
+        .groupBy(_._1)
+        .values
+        .map(_.map(_._2).toSet.size - 1)
+        .sum
+
+      // Strongly enforce target spread, then prefer fewer splits, then better club cohesion.
+      baseDeviation +
+        geraetePenalty +
+        spreadOverTarget.toLong * fairnessWeight * 10000L +
+        splitPenalty.toLong * splitWeight * 100L +
+        vereinFragmentation.toLong * cohesionWeight
+    }
   }
   
   @tailrec

--- a/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
@@ -9,6 +9,15 @@ import scala.annotation.tailrec
 trait StartGeraetGrouper extends RiegenSplitter with Stager {
   private val logger = LoggerFactory.getLogger(classOf[StartGeraetGrouper])
 
+  protected object BalanceConfig {
+    val strictFairnessAthletesPerDurchgang: Int = 40
+    val fairnessWeight: Int = 50
+    val splitWeight: Int = 30
+    val cohesionWeight: Int = 20
+
+    def targetDiff(participants: Int): Int = if participants <= strictFairnessAthletesPerDurchgang then 1 else 2
+  }
+
   def groupWertungen(programm: String, wertungen: Map[AthletView, Seq[WertungView]],
                      grp: List[WertungView => String], grpAll: List[WertungView => String],
                      startgeraete: List[Disziplin], maxRiegenSize: Int, splitSex: SexDivideRule, jahrgangGroup: Boolean)
@@ -33,22 +42,28 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       val athletensum = atheltenInRiege.flatMap {
         _._2.map(aw => aw._1.id)
       }.toSet.size
+      val targetDiff = BalanceConfig.targetDiff(athletensum)
       val maxRiegenSize2 = if maxRiegenSize > 0 then maxRiegenSize else math.max(14, math.ceil(1d * athletensum / startgeraeteSize).intValue())
-      val riegen = splitToMaxTurnerCount(atheltenInRiege, maxRiegenSize2, cache).map(r => Map(r._1 -> r._2))
+      val avoidSplitsForSmallDurchgang = athletensum <= startgeraeteSize
+      val riegen = (if avoidSplitsForSmallDurchgang then atheltenInRiege else splitToMaxTurnerCount(atheltenInRiege, maxRiegenSize2, cache))
+        .map(r => Map(r._1 -> r._2))
       // Maximalausdehnung. Nun die sinnvollen Zusammenlegungen
       val riegenindex = buildRiegenIndex(riegen)
       val workmodel = buildWorkModel(riegen)
 
       def combineToDurchgangSize(relevantcombis: GeraeteRiegen): GeraeteRiegen = {
+        val participants = relevantcombis.sizeOfAll
+        val localTargetDiff = BalanceConfig.targetDiff(participants)
         splitSex match {
           case GemischterDurchgang =>
             val rcm = relevantcombis.filter(c => c.turnerriegen.head.geschlecht.equalsIgnoreCase("M"))
             val rcw = relevantcombis.filter(c => c.turnerriegen.head.geschlecht.equalsIgnoreCase("W"))
             val maxMGeraete = startgeraeteSize * rcm.size / relevantcombis.size
             val maxWGeraete = startgeraeteSize * rcw.size / relevantcombis.size
-            buildPairs(maxMGeraete, maxRiegenSize2, rcm) ++ buildPairs(maxWGeraete, maxRiegenSize2, rcw)
+            buildPairs(maxMGeraete, maxRiegenSize2, rcm, localTargetDiff, BalanceConfig.fairnessWeight, BalanceConfig.splitWeight, BalanceConfig.cohesionWeight) ++
+              buildPairs(maxWGeraete, maxRiegenSize2, rcw, localTargetDiff, BalanceConfig.fairnessWeight, BalanceConfig.splitWeight, BalanceConfig.cohesionWeight)
           case _ =>
-            buildPairs(startgeraeteSize, maxRiegenSize2, relevantcombis)
+            buildPairs(startgeraeteSize, maxRiegenSize2, relevantcombis, localTargetDiff, BalanceConfig.fairnessWeight, BalanceConfig.splitWeight, BalanceConfig.cohesionWeight)
         }
       }
 
@@ -57,9 +72,9 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
           startriegen
         }
         else splitSex match {
-          case GemischteRiegen => bringVereineTogether(startriegen, maxRiegenSize2, splitSex)
+          case GemischteRiegen => bringVereineTogether(startriegen, maxRiegenSize2, splitSex, targetDiff)
           case GemischterDurchgang => startriegen
-          case GetrennteDurchgaenge => bringVereineTogether(startriegen, maxRiegenSize2, splitSex)
+          case GetrennteDurchgaenge => bringVereineTogether(startriegen, maxRiegenSize2, splitSex, targetDiff)
         }
       }
 
@@ -93,7 +108,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
   }
 
 
-  private def bringVereineTogether(startriegen: GeraeteRiegen, maxRiegenSize2: Int, splitSex: SexDivideRule): GeraeteRiegen = {
+  private def bringVereineTogether(startriegen: GeraeteRiegen, maxRiegenSize2: Int, splitSex: SexDivideRule, targetDiff: Int): GeraeteRiegen = {
     @tailrec
     def _bringVereineTogether(startriegen: GeraeteRiegen, variantsCache: Set[GeraeteRiegen]): GeraeteRiegen = {
       val averageSize = startriegen.averageSize
@@ -147,7 +162,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       if optimized == startriegen || variantsCache.contains(optimized) then {
         optimized
       } else {
-        val evenoptimized = spreadEven(optimized, splitSex)
+        val evenoptimized = spreadEven(optimized, splitSex, targetDiff)
         if evenoptimized == startriegen || variantsCache.contains(evenoptimized) then {
           evenoptimized
         } else {
@@ -179,22 +194,29 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
   }
 
   @tailrec
-  private def spreadEven(startriegen: GeraeteRiegen, splitSex: SexDivideRule, mustIncreaseQuality: Boolean = false): GeraeteRiegen = {
+  private def spreadEven(startriegen: GeraeteRiegen, splitSex: SexDivideRule, targetDiff: Int, mustIncreaseQuality: Boolean = false): GeraeteRiegen = {
     /*
    * 1. Durchschnittsgrösse ermitteln
    * 2. Grösste Abweichungen ermitteln (kleinste, grösste)
    * 3. davon (teilbare) Gruppen filtern
    * 4. schieben.
    */
-    val stats = startriegen.map { raw =>
+    type GrpStats = (squad.GeraeteRiege, Int, Int, Int, Option[TurnerRiege])
+    if startriegen.isEmpty then {
+      startriegen
+    }
+    else if startriegen.map(_.size).max - startriegen.map(_.size).min <= targetDiff then {
+      startriegen
+    }
+    else {
+    val stats: Seq[GrpStats] = startriegen.map { raw =>
       // Riege, Anz. Gruppen, Anz. Turner, Std.Abweichung, (kleinste Gruppekey, kleinste Gruppe)
       val anzTurner = raw.size
       val abweichung = anzTurner - startriegen.averageSize
-      (raw, raw.size, anzTurner, abweichung, raw.smallestDividable)
+      (raw, raw.size, raw.turnerriegen.size, abweichung, raw.smallestDividable)
     }.toSeq.sortBy(_._4).reverse // Abweichung
 
     val kleinsteGruppe@(geraeteRiegeAusKleinsterGruppe, _, anzGruppenAusKleinsterGruppe, _, turnerRiegeAusKleinsterGruppe) = stats.last
-    type GrpStats = (squad.GeraeteRiege, Int, Int, Int, Option[TurnerRiege])
 
     def checkSC(p1: GrpStats, p2: GrpStats): Boolean = {
       splitSex match {
@@ -207,10 +229,10 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
     }
 
     stats.find { groessteGruppe =>
-      val (geraeteRiege, _, anzGruppenAusGroessterGruppe, _, turnerRiege) = groessteGruppe
+      val (geraeteRiege, anzahlInGruppe, anzahlGruppen, abweichung, turnerRiege) = groessteGruppe
       val b11 = turnerRiege.isDefined && groessteGruppe != kleinsteGruppe
       val b12 = checkSC(groessteGruppe, kleinsteGruppe)
-      val b2 = anzGruppenAusGroessterGruppe > startriegen.averageSize
+      val b2 = anzahlInGruppe > startriegen.averageSize
       val b3 = b11 && turnerRiege.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize
       lazy val v1 = geraeteRiege.countVereine(turnerRiege.head.verein)
       lazy val v2 = kleinsteGruppe._1.countVereine(turnerRiege.head.verein)
@@ -226,7 +248,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
         val sg = geraeteRiegeAusKleinsterGruppe + turnerRiege
         val nextCombi = gt + startriegen.filter(sr => sr != geraeteRiege && sr != geraeteRiegeAusKleinsterGruppe) + sg
         if mustIncreaseQuality && nextCombi.quality > startriegen.quality then {
-          spreadEven(nextCombi, splitSex, mustIncreaseQuality)
+          spreadEven(nextCombi, splitSex, targetDiff, mustIncreaseQuality)
         } else {
           startriegen
         }
@@ -241,9 +263,10 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
         case Some(groessteGruppe@(geraeteRiegeAusGroessterGruppe, _, _, _, Some(turnerRiegeAusGroessterGruppe))) =>
           val gt = geraeteRiegeAusGroessterGruppe - turnerRiegeAusGroessterGruppe
           val sg = geraeteRiegeAusKleinsterGruppe + turnerRiegeAusGroessterGruppe
-          spreadEven(gt + startriegen.filter(sr => sr != geraeteRiegeAusGroessterGruppe && sr != geraeteRiegeAusKleinsterGruppe) + sg, splitSex, true)
+          spreadEven(gt + startriegen.filter(sr => sr != geraeteRiegeAusGroessterGruppe && sr != geraeteRiegeAusKleinsterGruppe) + sg, splitSex, targetDiff, true)
         case _ => startriegen
       } // inner stats find match
     } // stats find match
+    }
   }
 }

--- a/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
@@ -44,8 +44,12 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       }.toSet.size
       val targetDiff = BalanceConfig.targetDiff(athletensum)
       val maxRiegenSize2 = if maxRiegenSize > 0 then maxRiegenSize else math.max(14, math.ceil(1d * athletensum / startgeraeteSize).intValue())
+      // Pre-compute eqsize: when rounds > 1 are needed, TurnerRiegen must not exceed eqsize,
+      // otherwise mergeCandidates (which is capped at eqsize) cannot fully balance them.
+      val (effectiveSplitTarget, _) = computeDimensions(athletensum, startgeraeteSize, maxRiegenSize2)
       val avoidSplitsForSmallDurchgang = athletensum <= startgeraeteSize
-      val riegen = (if avoidSplitsForSmallDurchgang then atheltenInRiege else splitToMaxTurnerCount(atheltenInRiege, maxRiegenSize2, cache))
+      val riegen = (if avoidSplitsForSmallDurchgang then atheltenInRiege
+                    else splitToMaxTurnerCount(atheltenInRiege, effectiveSplitTarget, cache))
         .map(r => Map(r._1 -> r._2))
       // Maximalausdehnung. Nun die sinnvollen Zusammenlegungen
       val riegenindex = buildRiegenIndex(riegen)
@@ -89,13 +93,19 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
     if alignedriegen.isEmpty then {
       Seq.empty
     } else {
-      val missingStartOffset = math.min(startgeraete.size, alignedriegen.size)
+      val numDurchgaenge = math.ceil(alignedriegen.size.toDouble / startgeraete.size).toInt
+      // Sort descending by athlete count so each consecutive chunk of startgeraeteSize entries
+      // (= one Durchgang) is homogeneous in size → minimal intra-Durchgang spread.
+      val orderedRiegen = if numDurchgaenge <= 1 then alignedriegen
+                          else alignedriegen.sortBy(r => -r.sizeOfAll)
+
+      val missingStartOffset = math.min(startgeraete.size, orderedRiegen.size)
       val emptyGeraeteRiegen = Range(missingStartOffset, math.max(missingStartOffset, startgeraete.size))
         .map { startgeridx =>
           (s"$programm (1)", s"Leere Riege $programm/${startgeraete(startgeridx).easyprint}", startgeraete(startgeridx), Seq[(AthletView, Seq[WertungView])]())
         }
 
-      alignedriegen
+      orderedRiegen
         .zipWithIndex.flatMap { r =>
         val (rr, index) = r
         val startgeridx = (index + startgeraete.size) % startgeraete.size

--- a/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
+++ b/src/main/scala/ch/seidel/kutu/squad/StartGeraetGrouper.scala
@@ -31,10 +31,10 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       val atheltenInRiege = wertungen.groupBy(w => groupKey(grp)(w._2.head)).toSeq.map { x =>
         ( /*grpkey*/ x._1, // Riegenname
           /*values*/ x._2.foldLeft((Seq[(AthletView, Seq[WertungView])](), Set[Long]())) { (acc, w) =>
-          val (data, seen) = acc
-          val (athlet, _) = w
-          if seen.contains(athlet.id) then acc else (w +: data, seen + athlet.id)
-        }
+            val (data, seen) = acc
+            val (athlet, _) = w
+            if seen.contains(athlet.id) then acc else (w +: data, seen + athlet.id)
+          }
           ._1.sortBy(w => groupKey(grpAll)(w._2.head)) // Liste der Athleten in der Riege, mit ihren Wertungen
         )
       }
@@ -49,7 +49,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       val (effectiveSplitTarget, _) = computeDimensions(athletensum, startgeraeteSize, maxRiegenSize2)
       val avoidSplitsForSmallDurchgang = athletensum <= startgeraeteSize
       val riegen = (if avoidSplitsForSmallDurchgang then atheltenInRiege
-                    else splitToMaxTurnerCount(atheltenInRiege, effectiveSplitTarget, cache))
+      else splitToMaxTurnerCount(atheltenInRiege, effectiveSplitTarget, cache))
         .map(r => Map(r._1 -> r._2))
       // Maximalausdehnung. Nun die sinnvollen Zusammenlegungen
       val riegenindex = buildRiegenIndex(riegen)
@@ -97,7 +97,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       // Sort descending by athlete count so each consecutive chunk of startgeraeteSize entries
       // (= one Durchgang) is homogeneous in size → minimal intra-Durchgang spread.
       val orderedRiegen = if numDurchgaenge <= 1 then alignedriegen
-                          else alignedriegen.sortBy(r => -r.sizeOfAll)
+      else alignedriegen.sortBy(r => -r.sizeOfAll)
 
       val missingStartOffset = math.min(startgeraete.size, orderedRiegen.size)
       val emptyGeraeteRiegen = Range(missingStartOffset, math.max(missingStartOffset, startgeraete.size))
@@ -107,13 +107,13 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
 
       orderedRiegen
         .zipWithIndex.flatMap { r =>
-        val (rr, index) = r
-        val startgeridx = (index + startgeraete.size) % startgeraete.size
-        rr.keys.map { riegenname =>
-          logger.debug(s"Durchgang $programm (${index / startgeraete.size + 1}), Start ${startgeraete(startgeridx).easyprint}, ${rr(riegenname).size} Tu/Ti der Riege $riegenname")
-          (s"$programm (${if maxRiegenSize > 0 then index / startgeraete.size + 1 else 1})", riegenname, startgeraete(startgeridx), rr(riegenname))
-        }
-      } ++ emptyGeraeteRiegen
+          val (rr, index) = r
+          val startgeridx = (index + startgeraete.size) % startgeraete.size
+          rr.keys.map { riegenname =>
+            logger.debug(s"Durchgang $programm (${index / startgeraete.size + 1}), Start ${startgeraete(startgeridx).easyprint}, ${rr(riegenname).size} Tu/Ti der Riege $riegenname")
+            (s"$programm (${if maxRiegenSize > 0 then index / startgeraete.size + 1 else 1})", riegenname, startgeraete(startgeridx), rr(riegenname))
+          }
+        } ++ emptyGeraeteRiegen
     }
   }
 
@@ -140,7 +140,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
           acccStartriegen.find { p =>
             p != geraetRiege &&
               acccStartriegen.contains(geraetRiege) &&
-              p.countVereine(verein) > v1
+              p.countVereine(verein) >= v1
           }
           match {
             case Some(zielriege) if (zielriege ++ toMove).size <= maxRiegenSize2 =>
@@ -152,7 +152,7 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
               val r3 = r2 - geraetRiege
               val ret = r3 + gt
               ret
-            case Some(zielriege) => findSubstitutesFor(toMove, zielriege) match {
+            case Some(zielriege) => findSubstitutesFor(toMove, zielriege, maxRiegenSize2) match {
               case Some(substitues) =>
                 val gt = geraetRiege -- toMove ++ substitues
                 val sg = zielriege -- substitues ++ toMove
@@ -184,18 +184,26 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
     _bringVereineTogether(startriegen, Set(startriegen))
   }
 
-  private def findSubstitutesFor(riegeToReplace: squad.GeraeteRiege, zielriege: squad.GeraeteRiege): Option[squad.GeraeteRiege] = {
-    val replaceCnt = riegeToReplace.size
-    val reducedZielriege = zielriege -- riegeToReplace
+  private def findSubstitutesFor(riegeToReplace: squad.GeraeteRiege, zielriege: squad.GeraeteRiege, maxRiegenSize2: Int): Option[squad.GeraeteRiege] = {
+    // finde turnriegen möglichst eines Vereins in der zielriege, die nicht den verein von riegeToReplace haben, und deren ersatz durch die turnerriege von riegeToReplace die zielriege nicht über maxRiegenSize2 hinausbringen würde
+    val candidates = squad.GeraeteRiege(zielriege.turnerriegen
+      .filter{tr => riegeToReplace.countVereine(tr.verein).equals(0)}
+      .groupBy(tr => tr.verein)
+      .map{case (verein, tr) => (verein, tr.map(_.size).sum, tr)}
+      .toList.sortBy(_._2).reverse
+      .foldLeft(Seq.empty[TurnerRiege]){(acc, trt) =>
+        val (verein, size, trl) = trt
+        val candidate = acc ++ trl
+        val candidatesSize = candidate.map(_.size).sum
+        if candidatesSize <= riegeToReplace.size &&
+           zielriege.size - candidatesSize + riegeToReplace.size <= maxRiegenSize2 then {
+           candidate
+        } else {
+          acc
+        }
+      }.toSet
+    )
 
-    val candidates = reducedZielriege.turnerriegen.toSeq.sortBy(_.size).reverse.foldLeft(squad.GeraeteRiege()) { (acc, candidate) =>
-      val grouped = acc + candidate
-      if grouped.size <= replaceCnt then {
-        grouped
-      } else {
-        acc
-      }
-    }
     if candidates.nonEmpty then {
       Some(candidates)
     } else {
@@ -219,64 +227,64 @@ trait StartGeraetGrouper extends RiegenSplitter with Stager {
       startriegen
     }
     else {
-    val stats: Seq[GrpStats] = startriegen.map { raw =>
-      // Riege, Anz. Gruppen, Anz. Turner, Std.Abweichung, (kleinste Gruppekey, kleinste Gruppe)
-      val anzTurner = raw.size
-      val abweichung = anzTurner - startriegen.averageSize
-      (raw, raw.size, raw.turnerriegen.size, abweichung, raw.smallestDividable)
-    }.toSeq.sortBy(_._4).reverse // Abweichung
+      val stats: Seq[GrpStats] = startriegen.map { raw =>
+        // Riege, Anz. Gruppen, Anz. Turner, Std.Abweichung, (kleinste Gruppekey, kleinste Gruppe)
+        val anzTurner = raw.size
+        val abweichung = anzTurner - startriegen.averageSize
+        (raw, raw.size, raw.turnerriegen.size, abweichung, raw.smallestDividable)
+      }.toSeq.sortBy(_._4).reverse // Abweichung
 
-    val kleinsteGruppe@(geraeteRiegeAusKleinsterGruppe, _, anzGruppenAusKleinsterGruppe, _, turnerRiegeAusKleinsterGruppe) = stats.last
+      val kleinsteGruppe@(geraeteRiegeAusKleinsterGruppe, _, anzGruppenAusKleinsterGruppe, _, turnerRiegeAusKleinsterGruppe) = stats.last
 
-    def checkSC(p1: GrpStats, p2: GrpStats): Boolean = {
-      splitSex match {
-        case GemischterDurchgang =>
-          val ret = p1._1.turnerriegen.head.geschlecht.equals(p2._1.turnerriegen.head.geschlecht)
-          ret
-        case _ =>
-          true
-      }
-    }
-
-    stats.find { groessteGruppe =>
-      val (geraeteRiege, anzahlInGruppe, anzahlGruppen, abweichung, turnerRiege) = groessteGruppe
-      val b11 = turnerRiege.isDefined && groessteGruppe != kleinsteGruppe
-      val b12 = checkSC(groessteGruppe, kleinsteGruppe)
-      val b2 = anzahlInGruppe > startriegen.averageSize
-      val b3 = b11 && turnerRiege.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize
-      lazy val v1 = geraeteRiege.countVereine(turnerRiege.head.verein)
-      lazy val v2 = kleinsteGruppe._1.countVereine(turnerRiege.head.verein)
-      lazy val b4 = v1 - turnerRiege.size < v2 + turnerRiege.size
-      lazy val b5 = turnerRiege.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize + (anzGruppenAusKleinsterGruppe / 2)
-      lazy val b6 = v1 - turnerRiege.size == 0
-      lazy val b7 = v2 > 0
-
-      b11 && b12 && ((b2 && b3 && b4) || (b2 && b3 && b5 && b6 && b7))
-    } match {
-      case Some(groessteTeilbare@(geraeteRiege, _, _, _, Some(turnerRiege))) =>
-        val gt = geraeteRiege - turnerRiege
-        val sg = geraeteRiegeAusKleinsterGruppe + turnerRiege
-        val nextCombi = gt + startriegen.filter(sr => sr != geraeteRiege && sr != geraeteRiegeAusKleinsterGruppe) + sg
-        if mustIncreaseQuality && nextCombi.quality > startriegen.quality then {
-          spreadEven(nextCombi, splitSex, targetDiff, mustIncreaseQuality)
-        } else {
-          startriegen
+      def checkSC(p1: GrpStats, p2: GrpStats): Boolean = {
+        splitSex match {
+          case GemischterDurchgang =>
+            val ret = p1._1.turnerriegen.head.geschlecht.equals(p2._1.turnerriegen.head.geschlecht)
+            ret
+          case _ =>
+            true
         }
-      case _ => stats.find {
-        case groessteGruppe@(geraeteRiegeAusGroessterGruppe, _, anzGruppenAusGroessterGruppe, _, Some(turnerRiegeAusGroessterGruppe)) =>
-          groessteGruppe != kleinsteGruppe &&
-            checkSC(groessteGruppe, kleinsteGruppe) &&
-            anzGruppenAusGroessterGruppe > startriegen.averageSize &&
-            turnerRiegeAusGroessterGruppe.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize
-        case _ => false
+      }
+
+      stats.find { groessteGruppe =>
+        val (geraeteRiege, anzahlInGruppe, anzahlGruppen, abweichung, turnerRiege) = groessteGruppe
+        val b11 = turnerRiege.isDefined && groessteGruppe != kleinsteGruppe
+        val b12 = checkSC(groessteGruppe, kleinsteGruppe)
+        val b2 = anzahlInGruppe > startriegen.averageSize
+        val b3 = b11 && turnerRiege.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize
+        lazy val v1 = geraeteRiege.countVereine(turnerRiege.head.verein)
+        lazy val v2 = kleinsteGruppe._1.countVereine(turnerRiege.head.verein)
+        lazy val b4 = v1 - turnerRiege.size < v2 + turnerRiege.size
+        lazy val b5 = turnerRiege.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize + (anzGruppenAusKleinsterGruppe / 2)
+        lazy val b6 = v1 - turnerRiege.size == 0
+        lazy val b7 = v2 > 0
+
+        b11 && b12 && ((b2 && b3 && b4) || (b2 && b3 && b5 && b6 && b7))
       } match {
-        case Some(groessteGruppe@(geraeteRiegeAusGroessterGruppe, _, _, _, Some(turnerRiegeAusGroessterGruppe))) =>
-          val gt = geraeteRiegeAusGroessterGruppe - turnerRiegeAusGroessterGruppe
-          val sg = geraeteRiegeAusKleinsterGruppe + turnerRiegeAusGroessterGruppe
-          spreadEven(gt + startriegen.filter(sr => sr != geraeteRiegeAusGroessterGruppe && sr != geraeteRiegeAusKleinsterGruppe) + sg, splitSex, targetDiff, true)
-        case _ => startriegen
-      } // inner stats find match
-    } // stats find match
+        case Some(groessteTeilbare@(geraeteRiege, _, _, _, Some(turnerRiege))) =>
+          val gt = geraeteRiege - turnerRiege
+          val sg = geraeteRiegeAusKleinsterGruppe + turnerRiege
+          val nextCombi = gt + startriegen.filter(sr => sr != geraeteRiege && sr != geraeteRiegeAusKleinsterGruppe) + sg
+          if mustIncreaseQuality && nextCombi.quality > startriegen.quality then {
+            spreadEven(nextCombi, splitSex, targetDiff, mustIncreaseQuality)
+          } else {
+            startriegen
+          }
+        case _ => stats.find {
+          case groessteGruppe@(geraeteRiegeAusGroessterGruppe, _, anzGruppenAusGroessterGruppe, _, Some(turnerRiegeAusGroessterGruppe)) =>
+            groessteGruppe != kleinsteGruppe &&
+              checkSC(groessteGruppe, kleinsteGruppe) &&
+              anzGruppenAusGroessterGruppe > startriegen.averageSize &&
+              turnerRiegeAusGroessterGruppe.size + anzGruppenAusKleinsterGruppe <= startriegen.averageSize
+          case _ => false
+        } match {
+          case Some(groessteGruppe@(geraeteRiegeAusGroessterGruppe, _, _, _, Some(turnerRiegeAusGroessterGruppe))) =>
+            val gt = geraeteRiegeAusGroessterGruppe - turnerRiegeAusGroessterGruppe
+            val sg = geraeteRiegeAusKleinsterGruppe + turnerRiegeAusGroessterGruppe
+            spreadEven(gt + startriegen.filter(sr => sr != geraeteRiegeAusGroessterGruppe && sr != geraeteRiegeAusKleinsterGruppe) + sg, splitSex, targetDiff, true)
+          case _ => startriegen
+        } // inner stats find match
+      } // stats find match
     }
   }
 }

--- a/src/test/scala/ch/seidel/kutu/base/KuTuBaseSpec.scala
+++ b/src/test/scala/ch/seidel/kutu/base/KuTuBaseSpec.scala
@@ -3,7 +3,7 @@ package ch.seidel.kutu.base
 import java.sql.Date
 import java.util.UUID
 import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
+import org.apache.pekko.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import ch.seidel.kutu.domain.*
 import ch.seidel.kutu.http.ApiService
 import ch.seidel.kutu.squad.DurchgangBuilder
@@ -14,6 +14,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import java.time.{Instant, LocalDate}
 import java.time.temporal.ChronoUnit
+import scala.concurrent.duration.*
 
 trait KuTuBaseSpec extends AnyWordSpec
   with Matchers
@@ -23,6 +24,8 @@ trait KuTuBaseSpec extends AnyWordSpec
   with ScalaFutures
   with ScalatestRouteTest
   with BeforeAndAfterAll {
+
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(15.seconds) // or any duration you need
 
   DBService.startDB(Some(TestDBService.db))
 
@@ -46,7 +49,7 @@ trait KuTuBaseSpec extends AnyWordSpec
       val vereinID = createVerein(s"Verein-$v", Some(s"Verband-$v"))
       val athleten = for {
         pg <- (1 to pgIds.size) 
-        a <- (1 to Math.max(1, 4-pg))
+        a <- (1 to Math.max(1, anzvereine / pgIds.size * (pgIds.size - pg) + 1)) // Distribute athletes across programs
       } yield {
         val athlet = insertAthlete(Athlet(vereinID).copy(name = s"Athlet-$pg-$a"))
         val tuple: (Long, Option[Media]) = (athlet.id, None)

--- a/src/test/scala/ch/seidel/kutu/http/RegistrationRoutesReadAndMaintenanceScenariosSpec.scala
+++ b/src/test/scala/ch/seidel/kutu/http/RegistrationRoutesReadAndMaintenanceScenariosSpec.scala
@@ -8,12 +8,8 @@ import ch.seidel.kutu.mail.MockedSMTPMailer
 import org.apache.pekko.http.scaladsl.model.HttpMethods.GET
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
 import org.apache.pekko.http.scaladsl.model.{HttpRequest, MediaTypes, StatusCodes}
-import org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout
-
-import scala.concurrent.duration.*
 
 class RegistrationRoutesReadAndMaintenanceScenariosSpec extends KuTuBaseSpec {
-  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds) // or any duration you need
 
   // Keep mocked SMTP setup aligned with registration integration specs.
   private val mailer = new MockedSMTPMailer()

--- a/src/test/scala/ch/seidel/kutu/http/WettkampfRoutesSpec.scala
+++ b/src/test/scala/ch/seidel/kutu/http/WettkampfRoutesSpec.scala
@@ -9,17 +9,14 @@ import ch.seidel.kutu.domain.{ProgrammRaw, Wettkampf}
 import org.apache.pekko.http.scaladsl.model.*
 import org.apache.pekko.http.scaladsl.model.HttpMethods.{DELETE, GET, POST, PUT}
 import org.apache.pekko.http.scaladsl.model.headers.RawHeader
-import org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout
 import spray.json.*
 import spray.json.DefaultJsonProtocol.*
 
 import java.io.ByteArrayOutputStream
 import java.util.UUID
 import scala.compiletime.uninitialized
-import scala.concurrent.duration.*
 
 class WettkampfRoutesSpec extends KuTuBaseSpec {
-  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds) // or any duration you need
   private var testWettkampf: Wettkampf = uninitialized
 
   /** Competition whose zip is prepared in beforeAll; the DB entry is deleted before tests run so

--- a/src/test/scala/ch/seidel/kutu/squad/DurchgangBuilderSpec.scala
+++ b/src/test/scala/ch/seidel/kutu/squad/DurchgangBuilderSpec.scala
@@ -320,6 +320,37 @@ class DurchgangBuilderSpec extends KuTuBaseSpec {
       result should not be empty
     }
 
+    "have equal riegen sizes within each durchgang when forced into multiple durchgaenge" in {
+      // maxRiegenSize=5 forces multiple Durchgänge per category
+      val bigWk = insertGeTuWettkampf("IntraDurchgangBalanceWK", 20)
+      val builder = DurchgangBuilder(this)
+      val result = builder.suggestDurchgaenge(
+        bigWk.id,
+        maxRiegenSize = 5,
+        splitSexOption = Some(GemischteRiegen)
+      )
+
+      if (result.nonEmpty) {
+        result.foreach { case (durchgang, diszMap) =>
+          // Compare TOTAL athletes per Startgerät (Disziplin) within a Durchgang.
+          // A Startgerät may have several merged TurnerRiegen; their combined total should
+          // be near-equal to every other Startgerät's total in the same Durchgang.
+          val totalsPerDevice: Seq[Int] = diszMap.toSeq.map { case (_, riegenList) =>
+            riegenList.toSeq.flatMap { case (_, wertungen) =>
+              wertungen.map(_.athletId)
+            }.distinct.size
+          }.filter(_ > 0)
+
+          if (totalsPerDevice.size > 1) {
+            val diff = totalsPerDevice.max - totalsPerDevice.min
+            withClue(s"Durchgang '$durchgang': athletes-per-device=$totalsPerDevice") {
+              diff should be <= 2
+            }
+          }
+        }
+      }
+    }
+
     "distribute athletes evenly across riegen" in {
       testWettkampf = insertGeTuWettkampf("DistributionTestWK", 20)
       val builder = DurchgangBuilder(this)

--- a/src/test/scala/ch/seidel/kutu/squad/DurchgangBuilderSpec.scala
+++ b/src/test/scala/ch/seidel/kutu/squad/DurchgangBuilderSpec.scala
@@ -321,6 +321,7 @@ class DurchgangBuilderSpec extends KuTuBaseSpec {
     }
 
     "distribute athletes evenly across riegen" in {
+      testWettkampf = insertGeTuWettkampf("DistributionTestWK", 20)
       val builder = DurchgangBuilder(this)
       val result = builder.suggestDurchgaenge(
         testWettkampf.id,
@@ -331,14 +332,15 @@ class DurchgangBuilderSpec extends KuTuBaseSpec {
       if (result.nonEmpty) {
         result.values.foreach { durchgangMap =>
           durchgangMap.values.foreach { riegenList =>
-            if (riegenList.size > 1) {
-              val sizes = riegenList.map { case (_, wertungen) => wertungen.size }.toList.sorted
-              if (sizes.nonEmpty && sizes.max > 0) {
-                // The difference between smallest and largest riege should not be too large
-                // (reasonable distribution)
-                val difference = sizes.max - sizes.min
-                difference should be <= (sizes.max / 2 + 1)
-              }
+            val distribution = riegenList
+              .map { case (_, wertungen) => wertungen.map(_.athletId).distinct.size }
+              .filter(_ > 0)
+
+            if (distribution.nonEmpty) {
+              val participantsPerDurchgang = distribution.sum
+              val targetDifference = if (participantsPerDurchgang <= 40) 1 else 2
+              val difference = distribution.max - distribution.min
+              difference should be <= targetDifference
             }
           }
         }


### PR DESCRIPTION
This pull request introduces significant improvements to the team (Riegen) and apparatus (Geraete) grouping logic, focusing on fairer athlete distribution, enhanced club cohesion, and more flexible configuration for balancing. The changes add new weighting parameters, a stricter spread control for group sizes, and refactor several methods for clarity and extensibility. The main logic in `Stager`, `RiegenSplitter`, and `StartGeraetGrouper` is now more configurable and better at handling edge cases with small or uneven groups.

**Balancing and scoring improvements:**

* The `score` method in `Stager` now accepts additional parameters for target group size difference (`targetDiff`), and weights for fairness, split minimization, and club cohesion. The scoring formula has been extended to penalize excessive spread, unnecessary splits, and club fragmentation, making the grouping more balanced and club-friendly. [[1]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L16-R19) [[2]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L38-R39) [[3]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L47-R53) [[4]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L65-R91)
* The `buildPairs` and related methods now propagate these weights and target differences, allowing fine-tuned control over the grouping process. [[1]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L16-R19) [[2]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L38-R39) [[3]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3L47-R53)

**Configurable balancing logic:**

* A new `BalanceConfig` object in `StartGeraetGrouper` centralizes default weights and target difference logic, making it easier to adjust fairness and cohesion policies. The target spread is stricter for small competitions. [[1]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aR12-R20) [[2]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aR45-R70)
* The splitting and merging logic in `RiegenSplitter` and `StartGeraetGrouper` now consistently use computed target sizes and weights, improving predictability and maintainability. [[1]](diffhunk://#diff-5646d8b29085af5d6e4a4717d5b527678610edb4422242c00c7c9cf8d590a10bR11-R21) [[2]](diffhunk://#diff-5646d8b29085af5d6e4a4717d5b527678610edb4422242c00c7c9cf8d590a10bL22-R34) [[3]](diffhunk://#diff-5646d8b29085af5d6e4a4717d5b527678610edb4422242c00c7c9cf8d590a10bL35-R54) [[4]](diffhunk://#diff-5646d8b29085af5d6e4a4717d5b527678610edb4422242c00c7c9cf8d590a10bL53-R65) [[5]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aR45-R70) [[6]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL60-R81)

**Club cohesion and splitting enhancements:**

* Club cohesion is now more strongly enforced when bringing athletes from the same club together, and when searching for substitutes during group balancing. The substitute logic now respects the maximum allowed group size and avoids unnecessary fragmentation. [[1]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL118-R143) [[2]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL130-R155) [[3]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL150-R175) [[4]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL162-R206)
* The `spreadEven` method now uses the target difference and improved logic to minimize intra-group size differences, only redistributing when necessary. [[1]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL182-L197) [[2]](diffhunk://#diff-0cdc7a784c1d821b0be82418b20babd413ab2de4868dac71a53b7e61a2db355aL210-R253)

**Refactoring and code clarity:**

* Several methods have been renamed or refactored for clarity (e.g., `computeDimensions`/`computeDimensionsRec`), and parameters have been streamlined to reduce duplication and improve recursion. [[1]](diffhunk://#diff-b6c4b63875f8c094a67d58c992474240c75f6bf60f0d8e2b2d8bdc778c7614a3R167-R176) [[2]](diffhunk://#diff-5646d8b29085af5d6e4a4717d5b527678610edb4422242c00c7c9cf8d590a10bL35-R54)

**Bug fixes and minor improvements:**

* Fixed logic in club merging to allow moving athletes if the count is equal or greater, not just strictly greater.
* Group sorting and ordering have been improved to minimize spread within each Durchgang (competition round), especially for uneven group sizes.

These changes collectively make the grouping logic more robust, configurable, and fair, especially for edge cases and competitions with small or highly variable group sizes.